### PR TITLE
Don't use --network=host for the local docker test

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,18 @@ docker images
 To run the image locally:
 
 ```bash
-docker run --network=host -v ~/.config:/root/.config gcr.io/cloud-healthcare-containers/mllp-adapter /usr/mllp_adapter/mllp_adapter --hl7_v2_project_id=<PROJECT_ID> --hl7_v2_location_id=<LOCATION_ID> --hl7_v2_dataset_id=<DATASET_ID> --hl7_v2_store_id=<STORE_ID> --export_stats=false --receiver_ip=127.0.0.1 --pubsub_project_id=<PUBSUB_PROJECT_ID> --pubsub_subscription=<PUBSUB_SUBSCRIPTION_ID> --api_addr_prefix=<API_ADDR_PREFIX>
+docker run -p 2575:2575 -v ~/.config:/root/.config gcr.io/cloud-healthcare-containers/mllp-adapter /usr/mllp_adapter/mllp_adapter --hl7_v2_project_id=<PROJECT_ID> --hl7_v2_location_id=<LOCATION_ID> --hl7_v2_dataset_id=<DATASET_ID> --hl7_v2_store_id=<STORE_ID> --export_stats=false --receiver_ip=0.0.0.0 --pubsub_project_id=<PUBSUB_PROJECT_ID> --pubsub_subscription=<PUBSUB_SUBSCRIPTION_ID> --api_addr_prefix=<API_ADDR_PREFIX>
 ```
 
 In the command above:
-* `--network=host` is used to expose the port of the container;
+* `-p 2575:2575` is used to map the host port `2575` to MLLP container, which by default listent to port `2575`
 * `-v ~/.config:/root/.config` is used to give the container access
 to gcloud credentials;
 
 Also note that:
 * `PUBSUB_PROJECT_ID` and `PUBSUB_SUBSCRIPTION_ID` are available
 by creating a pubsub topic and a subscription on Google Cloud;
-* `API_ADDR_PREFIX` is of form `https://www.google.com:443/v1`, scheme, port and
-version should all be presented.
+* `API_ADDR_PREFIX` is of form `https://healthcare.googleapis.com:443/v1alpha2`, scheme. `443` here is the port, `v1alpha2` is the API version. Port and version should all be presented.
 
 You should be able to send HL7v2 messages now:
 


### PR DESCRIPTION
--network=host does not work on Docker for Mac so current instruction will lead to `connection refused` on Mac. Explicitly declare the port mapping and change the `receiver_ip` to `0.0.0.0` fixes the problem.